### PR TITLE
Update package.json to resolve depreciated warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage":
     "https://github.com/lwd-technology/react-app-rewire-imagemin-plugin#readme",
   "dependencies": {
-    "imagemin-webpack-plugin": "^1.5.2"
+    "imagemin-webpack-plugin": "^2.4.0"
   },
   "devDependencies": {
     "eslint": "^4.7.0",


### PR DESCRIPTION
eliminate the warning of 'Tapable.plugin is deprecated. Use new API on `.hooks` instead'