### PR TITLE
Fix: upgrade plugin to v2.4.2 and move to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,11 @@
   },
   "homepage":
     "https://github.com/lwd-technology/react-app-rewire-imagemin-plugin#readme",
-  "dependencies": {
-    "imagemin-webpack-plugin": "^1.5.2"
+  "peerDependencies": {
+    "imagemin-webpack-plugin": "^2.4.2"
   },
   "devDependencies": {
+    "imagemin-webpack-plugin": "^2.4.2"
     "eslint": "^4.7.0",
     "eslint-config-prettier": "^2.5.0",
     "eslint-config-standard": "^10.2.1",


### PR DESCRIPTION
- upgrade `imagemin-webpack-plugin` to v2.4.2 
- move to `peerDependencies` for wider range of configuration